### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,7 @@ author=Yuuichi Akagawa <@YuuichiAkagawa>
 maintainer=Yuuichi Akagawa <@YuuichiAkagawa>
 sentence=USB MIDI class driver for Arduino USB Host Shield 2.0 Library.
 paragraph=
+category=Communication
 url=https://github.com/YuuichiAkagawa/USBH_MIDI
 architectures=*
 


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library USBH_MIDI is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6.